### PR TITLE
use lodash.throttle

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   ],
   "scripts": {
     "build": "babel src --out-dir lib",
-    "test": "mocha --compilers js:babel-register --recursive ./test/*.spec.js",
+    "test": "mocha --compilers js:babel-register --recursive -r jsdom-global/register ./test/*.spec.js",
     "test:watch": "npm test -- --watch",
-    "prepublish": "npm run build"
+    "prepublish": "npm test && npm run build"
   },
   "repository": {
     "type": "git",
@@ -38,8 +38,8 @@
     "babel-register": "^6.9.0",
     "chai": "^3.5.0",
     "jsdom": "^9.4.2",
+    "jsdom-global": "^2.1.0",
     "mocha": "^3.0.2",
-    "mocha-jsdom": "^1.1.0",
     "react": "^15.3.2",
     "react-addons-test-utils": "^15.3.1",
     "sinon": "^1.17.5"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "react": "^15.0"
   },
   "dependencies": {
-    "hoist-non-react-statics": "^1.2.0"
+    "hoist-non-react-statics": "^1.2.0",
+    "lodash.throttle": "^4.1.1"
   },
   "devDependencies": {
     "babel-cli": "^6.9.0",
@@ -39,6 +40,7 @@
     "jsdom": "^9.4.2",
     "mocha": "^3.0.2",
     "mocha-jsdom": "^1.1.0",
+    "react": "^15.3.2",
     "react-addons-test-utils": "^15.3.1",
     "sinon": "^1.17.5"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -6,22 +6,22 @@ function getDisplayName(component) {
   return component.displayName || component.name
 }
 
-function throttleProps(component, wait) {
+function throttleProps(component, wait, options) {
   class Throttle extends Component {
     constructor(props, context) {
       super(props, context)
-      this.state = {props}
-      this.throttledSetState = throttle(this.setState, wait);
+      this.state = {}
+      this.throttledSetState = throttle(nextState => this.setState(nextState), wait, options)
     }
-
+    componentWillMount() {
+      this.throttledSetState({props: this.props})
+    }
     componentWillReceiveProps(nextProps) {
       this.throttledSetState({props: nextProps})
     }
-
-    shouldComponentUpdate(nextProps, nextState) {
-      return this.state !== nextState
+    componentWillUnmount() {
+      this.throttledSetState.cancel()
     }
-
     render() {
       return createElement(component, this.state.props)
     }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react'
 import TestUtils from 'react-addons-test-utils'
-import jsdom from 'mocha-jsdom'
 import sinon from 'sinon'
 import { expect } from 'chai'
 
@@ -12,8 +11,6 @@ before(function () { clock = sinon.useFakeTimers() })
 after(function () { clock.restore() })
 
 describe('throttle', function() {
-  jsdom()
-
   const Throttled = throttle(class extends Component {
     render() {
       const { value } = this.props
@@ -58,22 +55,20 @@ describe('throttle', function() {
     )
     expect(getValue(component)).to.equal('1')
 
-    component.setState({ value: '2' })
+    component.setState({value: '2'})
     expect(getValue(component)).to.equal('1')
     clock.tick(9)
     expect(getValue(component)).to.equal('1')
     clock.tick(1)
     expect(getValue(component)).to.equal('2')
 
-    component.setState({ value: '3' })
-    expect(getValue(component)).to.equal('2')
-    clock.tick(9)
-    expect(getValue(component)).to.equal('2')
-    clock.tick(1)
+    component.setState({value: '3'})
     expect(getValue(component)).to.equal('3')
 
-    clock.tick(10)
-    component.setState({ value: '4' })
+    component.setState({value: '4'})
+    clock.tick(9)
+    expect(getValue(component)).to.equal('3')
+    clock.tick(1)
     expect(getValue(component)).to.equal('4')
   })
 


### PR DESCRIPTION
Not sure if you want to use lodash.throttle but it makes the code much simpler.

This PR also fixes a few dev issues I encountered:
- `mocha-jsdom` was preventing test errors from being printed.  Using `jsdom-global` instead fixed this
- `react` was missing from `devDependencies`
- `prepublish` ought to run `npm test`

I had to change the timing of the throttle test, `lodash.throttle` seems to behave a bit strangely with Sinon fake timers.